### PR TITLE
Fix integer overflow on 32 bit builds

### DIFF
--- a/params.go
+++ b/params.go
@@ -372,7 +372,7 @@ func parseParamsFromName(name string) (*Params, Error) {
 		if err != nil {
 			return nil, wrapErrorf(err, "Can't parse D")
 		}
-		if d < 0 || d >= 1<<32 {
+		if d < 0 || int64(d) >= int64(1)<<32 {
 			return nil, errorf("D out of bounds")
 		}
 		ret.D = uint32(d)
@@ -388,7 +388,7 @@ func parseParamsFromName(name string) (*Params, Error) {
 	if err != nil {
 		return nil, wrapErrorf(err, "Can't parse FullHeight")
 	}
-	if fh < 0 || fh >= 1<<32 {
+	if fh < 0 || int64(fh) >= int64(1)<<32 {
 		return nil, errorf("FullHeight out of bounds")
 	}
 	ret.FullHeight = uint32(fh)
@@ -397,7 +397,7 @@ func parseParamsFromName(name string) (*Params, Error) {
 	if err != nil {
 		return nil, wrapErrorf(err, "parse N")
 	}
-	if n < 0 || n > 1<<32 {
+	if n < 0 || int64(n) > int64(1)<<32 {
 		return nil, errorf("N out of bounds")
 	}
 	ret.N = uint32(n) / 8


### PR DESCRIPTION
Fix for an integer overflow in 32 bit builds that we encountered during building of [`irmamobile`](https://github.com/privacybydesign/irmamobile), which depends on this.

The problem may be reproduced e.g. as follows:

```
env GOOS=linux GOARCH=386 go build .
# github.com/bwesterb/go-xmssmt
./params.go:375:20: 1 << 32 (untyped int constant 4294967296) overflows int
./params.go:391:21: 1 << 32 (untyped int constant 4294967296) overflows int
./params.go:400:18: 1 << 32 (untyped int constant 4294967296) overflows int
```